### PR TITLE
Add tests for bug with repeated rows

### DIFF
--- a/test/BugTest.php
+++ b/test/BugTest.php
@@ -1,9 +1,9 @@
 <?php
 class BugTest extends DaffTestCase {
 	
-/**
- * Test rows are ordered correctly when a row is removed
- */
+	/**
+	* Test rows are ordered correctly when a row is removed
+	*/
 	public function testIssue11() {
 		$data1 = [
 			['Country','Capital'],
@@ -33,4 +33,45 @@ class BugTest extends DaffTestCase {
 			$this->assertEquals($row, $sortedRow);
 		}
 	}
+
+	public function testPatchWithRepeatedRows() {
+		$localTable = [
+			['a', 'b'],
+			[2, 2],
+			[2, 2],
+			[5, 6],
+		];
+
+		$remoteTable = [
+			['a', 'b'],
+			[5, 100],
+		];
+
+		$expectedTable = [
+			['a', 'b'],
+			[5, 100],
+		];
+
+		$local = new coopy_PhpTableView($localTable);
+		$remote = new coopy_PhpTableView($remoteTable);
+
+		$dataDiff = [];
+		$tableDiff = new coopy_PhpTableView($dataDiff);
+
+		$highlighter = new coopy_TableDiff(coopy_Coopy::compareTables($local, $remote)->align(), new coopy_CompareFlags());
+		$highlighter->hilite($tableDiff);
+
+		$patch = new coopy_HighlightPatch(
+			$local,
+			$tableDiff
+		);
+		$patch->apply();
+		$patchedData = $local->getData();
+
+		$this->assertEquals(2, count($patchedData));
+		for ($i = 0; $i < 2; $i++) {
+			$this->assertEmpty(array_diff($patchedData[i], $expectedTable[i]));
+		}
+	}
+
 }


### PR DESCRIPTION
Hello,

We've found a weird behavior in your library's patching feature. I've written a test that shows the problem.

I decided to report it here because I'm not sure whether the problem is PHP-only.

Thanks for your time